### PR TITLE
Add email meta data to profile on signup.

### DIFF
--- a/components/FrontPage/Modals/SignupModal.tsx
+++ b/components/FrontPage/Modals/SignupModal.tsx
@@ -49,7 +49,8 @@ export default function SignupModal(props: { handleInputClickStepThree: () => vo
       password,
       options: {
         data: {
-          user_name: name
+          user_name: name,
+          email: email
         },
         emailRedirectTo: `${location.origin}/home`
       }


### PR DESCRIPTION
The `profile` table within the database now has an email column. I added the email metadata to be sent on signup.