### PR TITLE
Fix signup fetch requests

### DIFF
--- a/components/FrontPage/Modals/SignUpStepOne.tsx
+++ b/components/FrontPage/Modals/SignUpStepOne.tsx
@@ -14,7 +14,7 @@ export default function SignUpStepOne(props: {
 
     async function userNameNotTaken(username: string) {
         try {
-            const checkUsername = await fetch(`http://localhost:3000/api/user/${username}`);
+            const checkUsername = await fetch(`/api/user/${username}`);
 
             if (checkUsername.status === 404) {
                 handleUniqueUsername(true);
@@ -32,7 +32,7 @@ export default function SignUpStepOne(props: {
 
     async function emailNotTaken(email: string) {
         try {
-            const checkEmail = await fetch(`http://localhost:3000/api/user/register/${email}`);
+            const checkEmail = await fetch(`/api/user/register/${email}`);
 
             if (checkEmail.status === 404) {
                 handleUniqueEmail(true);


### PR DESCRIPTION
The fetch function was making a request to `localhost:3000`. I removed it to make the correct fetch request to the route handler when deployed on Vercel.