### PR TITLE
Private profile feature

### DIFF
--- a/app/(authenticated)/home/page.tsx
+++ b/app/(authenticated)/home/page.tsx
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { getUserSessionID, getUserDataByID } from "@/lib/getUserData";
 
+import type { UserData } from "@/lib/types/userdata.types";
 
 export default async function Home() {
     const cookieStore = cookies();
@@ -12,19 +13,27 @@ export default async function Home() {
 
     const session = await getUserSessionID(supabase);
 
-    if(!session) {
-        console.error("[/home getUserSessionID() Error]: Check logs.");
-        return null;
+    if(session.error) {
+        const statusError = session.error.status;
+
+        if(statusError === 500) {
+            console.error(`Home Component Status Error 500: ${session.error.message}`);
+            return null;
+        } else if (statusError === 403) redirect("/");
     }
 
-    if(!session.id) redirect("/");
+    const getCurrentUser = await getUserDataByID(supabase, session.id);
 
-    const currentUser = await getUserDataByID(supabase, session.id);
+    if(getCurrentUser.error) {
+        const statusError = getCurrentUser.error.status;
 
-    if(!currentUser) {
-        console.error("[/home getUserDataByID() Error]: Check logs.");
-        return null;
+        if(statusError === 500) {
+            console.error(`Home Component Status Error 500: ${getCurrentUser.error.message}`);
+            return null;
+        } else if (statusError === 404) redirect("/");
     }
+
+    const currentUser = getCurrentUser.userData as UserData;
 
     return (
         <MainComponent currentUser={currentUser} />

--- a/app/api/tweet/[username]/route.ts
+++ b/app/api/tweet/[username]/route.ts
@@ -1,86 +1,21 @@
 import { cookies } from "next/headers";
-import { sql, eq, and, desc, exists } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 
 import { createClient } from "@/lib/supabase/server";
-import { db } from "@/lib/db";
-import * as schemas from "@/lib/db/schema";
 
-export async function GET(req: NextRequest, { params }: { params: { username: string }}) {
+export async function GET(req: NextRequest, { params }: { params: { username: string } }) {
     const { username } = params;
     const cookieStore = cookies();
     const supabase = await createClient(cookieStore);
 
-    const { data, error } = await supabase.auth.getSession();
+    const { data: getUserTweets, error: getUserTweetsErr } = await supabase
+        .from("secured_tweets")
+        .select("*")
+        .eq("user_name", username);
 
-    if(error) {
-        console.error("/api/tweet/[username] Error: ", error);
-        return NextResponse.json({ Error: "Check console for details." }, { status: 500 });
+    if (getUserTweetsErr) {
+        return NextResponse.json({ Error: "Server error retrieving tweets. Please try again." }, { status: 200 });
     }
 
-    if(!data.session) {
-        const getUserTweets = await db.select({
-            id: schemas.tweet.id,
-            authorInfo: {
-                authorDisplayName: sql<string>`${schemas.profile.displayName}`,
-                authorUserName: sql<string>`${schemas.profile.userName}`,
-                authorAvatarUrl: sql<string>`${schemas.profile.avatarUrl}`,
-                authorHeaderUrl: sql<string>`${schemas.profile.headerUrl}`,
-            },
-            textContent: schemas.tweet.postContent,
-            likeCount: sql<string>`COUNT(DISTINCT(${schemas.like.id}))`,
-            replyCount: sql<string>`COUNT(DISTINCT(${schemas.reply.id}))`,
-            createdAt: sql<string>`${schemas.tweet.createdAt}`,
-            isReply: schemas.tweet.isReply
-        })
-        .from(schemas.tweet)
-        .leftJoin(schemas.profile, eq(schemas.tweet.profileID, schemas.profile.id))
-        .leftJoin(schemas.like, eq(schemas.tweet.id, schemas.like.tweetID))
-        .leftJoin(schemas.reply, eq(schemas.tweet.id, schemas.reply.replyTo))
-        .where(eq(schemas.profile.userName, username))
-        .orderBy(desc(schemas.tweet.createdAt))
-        .groupBy(schemas.tweet.id, schemas.profile.id)
-        .limit(50);
-
-        return NextResponse.json(getUserTweets, { status: 200 });
-    } else {
-        const sessionID: string = data.session.user.id;
-        const getUserTweets = await db.select({
-            id: schemas.tweet.id,
-            authorInfo: {
-                authorDisplayName: sql<string>`${schemas.profile.displayName}`,
-                authorUserName: sql<string>`${schemas.profile.userName}`,
-                authorAvatarUrl: sql<string>`${schemas.profile.avatarUrl}`,
-                authorHeaderUrl: sql<string>`${schemas.profile.headerUrl}`,
-            },
-            textContent: schemas.tweet.postContent,
-            likeCount: sql<string>`COUNT(${schemas.like.id})`,
-            replyCount: sql<string>`COUNT(${schemas.reply.id})`,
-            createdAt: sql<string>`${schemas.tweet.createdAt}`,
-            hasLikedTweet: sql<boolean>`
-                EXISTS(
-                    SELECT
-                        1
-                    FROM
-                        ${schemas.like}
-                    WHERE
-                        ${schemas.like.userID} = ${sessionID}
-                    AND
-                        ${schemas.like.tweetID} = ${schemas.tweet.id}
-                )
-            `,
-            isReply: schemas.tweet.isReply
-        })
-        .from(schemas.tweet)
-        .leftJoin(schemas.profile, eq(schemas.tweet.profileID, schemas.profile.id))
-        .leftJoin(schemas.like, eq(schemas.tweet.id, schemas.like.tweetID))
-        .leftJoin(schemas.reply, eq(schemas.tweet.id, schemas.reply.replyTo))
-        .where(eq(schemas.profile.userName, username))
-        .orderBy(desc(schemas.tweet.createdAt))
-        .groupBy(schemas.tweet.id, schemas.profile.id)
-        .limit(50);
-
-        return NextResponse.json(getUserTweets, { status: 200 });
-    }
-
+    return NextResponse.json(getUserTweets, { status: 200 });
 }

--- a/app/api/tweet/route.ts
+++ b/app/api/tweet/route.ts
@@ -1,49 +1,18 @@
 import { cookies } from "next/headers";
-import { sql, eq, and, desc } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 
 import { createClient } from "@/lib/supabase/server";
-import { db } from "@/lib/db";
-import * as schemas from "@/lib/db/schema";
 
 export async function GET(req: NextRequest) {
     const cookieStore = cookies();
     const supabase = await createClient(cookieStore);
 
-    const { data, error } = await supabase.auth.getSession();
+    const { data: getAllTweets, error: getAllTweetsErr } = await supabase
+        .from("secured_tweets")
+        .select(`*`)
+        .eq("is_reply", false)
 
-    if(error) {
-        console.error("/api/tweet/ Error: ", error);
-        return NextResponse.json({ "Error": "Check console for details." }, { status: 500 });
-    }
+    if (getAllTweetsErr) return NextResponse.json({ Error: "Server failed to retrieve tweets. Please try again." }, { status: 500 });
 
-    const getAllTweets = await db.select({
-        id: schemas.tweet.id,
-        authorInfo: {
-            authorDisplayName: sql<string>`${schemas.profile.displayName}`,
-            authorUserName: sql<string>`${schemas.profile.userName}`,
-            authorAvatarUrl: sql<string>`${schemas.profile.avatarUrl}`,
-            authorHeaderUrl: sql<string>`${schemas.profile.headerUrl}`,
-        },
-        textContent: schemas.tweet.postContent,
-        likeCount: sql<string>`COUNT(DISTINCT(${schemas.like.id}))`,
-        replyCount: sql<string>`COUNT(DISTINCT(${schemas.reply.id}))`,
-        createdAt: sql<string>`${schemas.tweet.createdAt}`,
-        hasLikedTweet: data.session ? sql<boolean>`EXISTS(
-            ${db.select()
-                .from(schemas.like)
-                .where(and(eq(schemas.like.userID, data.session.user.id), eq(schemas.tweet.id, schemas.like.tweetID)))}
-        )` : sql<boolean>`false`,
-        isReply: schemas.tweet.isReply
-    })
-        .from(schemas.tweet)
-        .leftJoin(schemas.profile, eq(schemas.tweet.profileID, schemas.profile.id))
-        .leftJoin(schemas.like, eq(schemas.tweet.id, schemas.like.tweetID))
-        .leftJoin(schemas.reply, eq(schemas.tweet.id, schemas.reply.replyTo))
-        .where(eq(schemas.tweet.isReply, false))
-        .orderBy(desc(schemas.tweet.createdAt))
-        .groupBy(schemas.tweet.id, schemas.profile.id)
-        .limit(50);
-    
     return NextResponse.json(getAllTweets, { status: 200 });
 }

--- a/components/MainSection/PostComponent.tsx
+++ b/components/MainSection/PostComponent.tsx
@@ -16,7 +16,7 @@ export default function PostComponent(props: { tweet: Tweet, currentUser: UserDa
   let threadLine: boolean = true;
 
   function handleBackgroundClick() {
-    router.push(`/${tweet.authorInfo.authorUserName}/status/${tweet.id}`);
+    router.push(`/${tweet.user_name}/status/${tweet.id}`);
   }
 
   if(!isThread) threadLine = false;

--- a/components/MainSection/PostComponent/InteractionComponent.tsx
+++ b/components/MainSection/PostComponent/InteractionComponent.tsx
@@ -17,8 +17,8 @@ import type { UserData } from "@/lib/types/userdata.types";
 
 export default function InteractionComponent(props: { tweet: Tweet, currentUser: UserData }) {
     const { tweet, currentUser } = props;
-    const [likes, setLikes] = useState(parseInt(tweet.likeCount));
-    const [replies, setReplies] = useState(parseInt(tweet.replyCount));
+    const [likes, setLikes] = useState(tweet.like_count);
+    const [replies, setReplies] = useState(tweet.reply_count);
     const [likedPost, setLikedPost] = useState(false);
 
     const supabase = createClient();
@@ -42,19 +42,25 @@ export default function InteractionComponent(props: { tweet: Tweet, currentUser:
             }
 
         } else {
-            await supabase
+            const { data, error } = await supabase
                 .from("like")
                 .delete()
                 .eq("user_id", currentUser.id)
                 .eq("tweet_id", tweet.id);
 
-            setLikedPost(false);
-            setLikes(likes - 1);
+            if (error) {
+                console.error("handleLike() Error: ", error);
+            }
+
+            if (data) {
+                setLikedPost(false);
+                setLikes(likes - 1);
+            }
         }
     }
 
     useMemo(() => {
-        if (tweet.hasLikedTweet) setLikedPost(true);
+        if (tweet.has_liked_tweet) setLikedPost(true);
     }, []);
 
     return (
@@ -93,7 +99,7 @@ export default function InteractionComponent(props: { tweet: Tweet, currentUser:
             <div onClick={fgClick}>
                 <div className="flex flex-row items-center cursor-pointer group">
                     <div className="h-full p-2 rounded-full group-hover:bg-primary/20">
-                        <IoIosStats className="group-hover:text-primary"/>
+                        <IoIosStats className="group-hover:text-primary" />
                     </div>
                     <span className="text-sm font-light px-2 group-hover:text-primary">{statToString(10842)}</span>
                 </div>

--- a/components/MainSection/PostComponent/PostAuthorIconComponent.tsx
+++ b/components/MainSection/PostComponent/PostAuthorIconComponent.tsx
@@ -10,12 +10,12 @@ export default function PostAuthorIconComponent(props: { tweet?: Tweet, userData
     if (!tweet && userData) {
         imgSrc = userData.avatarUrl;
     } else if (tweet && !userData) {
-        imgSrc = tweet.authorInfo.authorAvatarUrl;
+        imgSrc = tweet.avatar_url;
     } else if (!tweet && !userData) {
         console.error("PostAuthorIconComponent Error: Missing tweet prop or userData prop!");
         return null;
     } else if (tweet && userData) {
-        imgSrc = tweet.authorInfo.authorAvatarUrl;
+        imgSrc = tweet.avatar_url;
     }
 
     return (

--- a/components/MainSection/PostComponent/PostContentComponent.tsx
+++ b/components/MainSection/PostComponent/PostContentComponent.tsx
@@ -13,11 +13,11 @@ export default function PostContentComponent(props: { tweet: Tweet }) {
         <div className="ml-2">
             <div className="flex flex-row justify-between w-full">
                 <div className="flex flex-row text-sm justify-between">
-                    <span className="font-bold">{tweet.authorInfo.authorDisplayName}</span>
+                    <span className="font-bold">{tweet.display_name}</span>
                     <div className="flex flex-row ml-2 font-light">
-                        <span className="text-slate/75">@{tweet.authorInfo.authorUserName}</span>
+                        <span className="text-slate/75">@{tweet.user_name}</span>
                         <BsDot className="h-full text-slate/75" />
-                        <span className="text-slate/75">{dayjs(tweet.createdAt).fromNow()}</span>
+                        <span className="text-slate/75">{dayjs(tweet.created_at).fromNow()}</span>
                     </div>
                 </div>
                 <div>
@@ -25,7 +25,7 @@ export default function PostContentComponent(props: { tweet: Tweet }) {
                 </div>
             </div>
             <div id="post" className="text-sm font-light mb-2">
-                <span>{tweet.textContent}</span>
+                <span>{tweet.post_content}</span>
             </div>
         </div>
     )

--- a/components/NavSection/ToolTipComponent.tsx
+++ b/components/NavSection/ToolTipComponent.tsx
@@ -10,7 +10,7 @@ import { BiDotsHorizontalRounded } from "react-icons/bi";
 
 import type { UserData } from "@/lib/types/userdata.types";
 
-export default function ToolTipComponent(props: { userData: UserData }) {
+function LoggedInToolTipComponent(props: { userData: UserData }) {
     const { userData } = props;
 
     const [logoutTooltip, setLogoutTooltip] = useState(false);
@@ -40,13 +40,13 @@ export default function ToolTipComponent(props: { userData: UserData }) {
                     <div className="flex flex-col" onClick={handleLogout}>
                         <div className="relative h-[40px] flex flex-col justify-center hover:bg-rlgrey/30 hover:cursor-pointer p-4 rounded-lg">
                             <span className="font-bold text-lg">Log out @{userData.userName}</span>
-                        {
-                            clickedLogout && (
-                                <div className="absolute h-full w-full top-0 left-0 flex flex-col justify-center bg-black rounded-lg">
-                                    <Spinner color="blue" className="mx-auto"/>
-                                </div>
-                            )
-                        }
+                            {
+                                clickedLogout && (
+                                    <div className="absolute h-full w-full top-0 left-0 flex flex-col justify-center bg-black rounded-lg">
+                                        <Spinner color="blue" className="mx-auto" />
+                                    </div>
+                                )
+                            }
                         </div>
                     </div>
                 }
@@ -68,6 +68,21 @@ export default function ToolTipComponent(props: { userData: UserData }) {
             </Tooltip>
             {
                 logoutTooltip && <div id="tooltip-click" className="absolute h-full w-full left-0 top-0" onClick={handleCloseLogoutTooltip}></div>
+            }
+        </>
+    );
+}
+
+export default function ToolTipComponent(props: { userData: UserData | null }) {
+    const { userData } = props;
+
+    return (
+        <>
+            {
+                userData ?
+                    <LoggedInToolTipComponent userData={userData} />
+                    :
+                    null
             }
         </>
     )

--- a/components/Profile/IconHeaderComponent.tsx
+++ b/components/Profile/IconHeaderComponent.tsx
@@ -12,15 +12,8 @@ export default function IconHeaderComponent(props: { currentUser: UserData, user
                 <Image src={userProfile.headerUrl} alt="" width={1500} height={500} />
                 <Image src={userProfile.avatarUrl} alt="" className="rounded-full absolute top-[130px] left-4 border-4 border-black" height={130} width={130} />
             </div>
-
             {
-                currentUser.userName === "" && (
-                    <div className="w-full my-8"></div>
-                )
-            }
-
-            {
-                (currentUser.userName !== "" && currentUser.userName !== userProfile.userName) && (
+                (currentUser.userName !== userProfile.userName) && (
                     <div className="w-full">
                         <span className="float-right border rounded-full font-semibold border-slate/75 px-4 py-2 m-2">Follow</span>
                     </div>

--- a/components/Profile/ProfileDashboardComponent.tsx
+++ b/components/Profile/ProfileDashboardComponent.tsx
@@ -4,13 +4,12 @@ import { useState } from "react";
 
 import TweetsDisplayDashboard from "../MainSection/TweetsDisplayDashboard";
 
-import type { Tweet } from "@/lib/types/tweet.types";
 import type { UserData } from "@/lib/types/userdata.types";
 
 type TabSelect = "Posts" | "Replies" | "Media" | "Likes";
 const tabSelectInit: TabSelect = "Posts";
 
-export default function ProfileDashboardComponent(props: { currentUser: UserData, username?: string }) {
+function AuthorizedDashboardComponent(props: { currentUser: UserData, username?: string }) {
   const { currentUser, username } = props;
   const [tab, setTab] = useState(tabSelectInit);
 
@@ -59,5 +58,23 @@ export default function ProfileDashboardComponent(props: { currentUser: UserData
         )
       }
     </div>
+  )
+}
+
+export default function ProfileDashboardComponent(props: { currentUser: UserData, authorized: boolean, username?: string }) {
+  const { currentUser, authorized, username } = props;
+
+  return (
+    <>
+      {
+        authorized ?
+          <AuthorizedDashboardComponent currentUser={currentUser} username={username} />
+          :
+          <div className="flex flex-col px-32">
+            <span className="text-3xl font-bold">These posts are protected</span>
+            <span className="text-slate/75 text-sm">Only approved followers can see @{username}’s posts. To request access, click Follow. <span className="text-primary">Learn more</span></span>
+          </div>
+      }
+    </>
   )
 }

--- a/components/Profile/UserPostInteractionComponent.tsx
+++ b/components/Profile/UserPostInteractionComponent.tsx
@@ -17,7 +17,7 @@ import { UserData } from "@/lib/types/userdata.types";
 export default function UserPostInteractionComponent(props: { tweet: Tweet, replies: Tweet[], currentUser: UserData, postID: string }) {
     const { tweet, replies, currentUser, postID } = props;
     const [likedPost, setLikedPost] = useState(false);
-    const [likeCount, setLikeCount] = useState(parseInt(tweet.likeCount));
+    const [likeCount, setLikeCount] = useState(tweet.like_count);
     const supabase = createClient();
 
     async function handleLike() {
@@ -51,7 +51,7 @@ export default function UserPostInteractionComponent(props: { tweet: Tweet, repl
     }
 
     useEffect(() => {
-        if(tweet.hasLikedTweet) setLikedPost(true);
+        if(tweet.has_liked_tweet) setLikedPost(true);
     }, []);
 
     return (

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -10,6 +10,7 @@ export const profile = pgTable("profile", {
     avatarUrl: text("avatar_url").default("https://cltgswnlsgvjrfszkaiz.supabase.co/storage/v1/object/public/avatar/default.jpg").notNull(),
     headerUrl: text("header_url").default("https://cltgswnlsgvjrfszkaiz.supabase.co/storage/v1/object/public/header/default.jpg").notNull(),
     bio: text("bio").default("").notNull(),
+    privateProfile: boolean("private_profile").notNull().default(false),
 });
 
 export const tweet = pgTable("tweet", {

--- a/lib/getTweetData.ts
+++ b/lib/getTweetData.ts
@@ -1,45 +1,33 @@
-import { eq, sql, desc, and } from "drizzle-orm";
-import { db } from "./db";
-import * as schemas from "./db/schema";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Tweet } from "./types/tweet.types";
 
-export async function getTweetData(tweetID: string, currentUserID?: string) {
-    const getUserTweets = await db.select({
-        id: schemas.tweet.id,
-        authorInfo: {
-            authorDisplayName: sql<string>`${schemas.profile.displayName}`,
-            authorUserName: sql<string>`${schemas.profile.userName}`,
-            authorAvatarUrl: sql<string>`${schemas.profile.avatarUrl}`,
-            authorHeaderUrl: sql<string>`${schemas.profile.headerUrl}`,
-        },
-        textContent: schemas.tweet.postContent,
-        likeCount: sql<string>`COUNT(DISTINCT(${schemas.like.id}))`,
-        replyCount: sql<string>`COUNT(DISTINCT(${schemas.reply.id}))`,
-        createdAt: sql<string>`${schemas.tweet.createdAt}`,
-        isReply: sql<boolean>`${schemas.tweet.isReply}`,
-        hasLikedTweet: currentUserID ? sql<boolean>`EXISTS(
-            ${db.select()
-                .from(schemas.like)
-                .where(and(eq(schemas.like.userID, currentUserID), eq(schemas.tweet.id, schemas.like.tweetID)))}
-        )` : sql<boolean>`false`,
-    })
-    .from(schemas.tweet)
-    .where(eq(schemas.tweet.id, tweetID))
-    .leftJoin(schemas.profile, eq(schemas.tweet.profileID, schemas.profile.id))
-    .leftJoin(schemas.like, eq(schemas.tweet.id, schemas.like.tweetID))
-    .leftJoin(schemas.reply, eq(schemas.tweet.id, schemas.reply.replyTo))
-    .orderBy(desc(schemas.tweet.createdAt))
-    .groupBy(schemas.tweet.id, schemas.profile.id);
+export async function getTweetData(supabase: SupabaseClient<any, "public", any>, tweetID: string): Promise<{ error: { status: 500 | 401, message: string } | null, data: Tweet | null }> {
+    const { data: getUserTweets, error: getUserTweetsErr } = await supabase
+        .from("secured_tweets")
+        .select("*")
+        .eq("id", tweetID);
 
-    return getUserTweets;
+    if (getUserTweetsErr) {
+        console.error("getTweetData() Error: ", getUserTweetsErr);
+        return { error: { status: 500, message: "Server error getting user tweet. Check logs for details." }, data: null };
+    }
+
+    const tweet: Tweet = getUserTweets[0];
+
+    return { error: null, data: tweet };
 }
 
-export async function getTweetReplyIDs(tweetID: string) {
-    const getTweetReplies = await db.select({
-        id: schemas.tweet.id
-    })
-    .from(schemas.reply)
-    .leftJoin(schemas.tweet, eq(schemas.tweet.id, schemas.reply.id))
-    .where(eq(schemas.reply.replyTo, tweetID));
+export async function getTweetReplies(supabase: SupabaseClient<any, "public", any>, tweetID: string): Promise<{ error: { status: number, message: string } | null, data: Tweet[] | null }> {
+    const { data: tweetReplies, error } = await supabase
+        .from("secured_tweets")
+        .select("*")
+        .eq("reply_to", tweetID);
 
-    return getTweetReplies;
+    if(error) {
+        console.error("getTweetReplies() 500 Error: ", error);
+        return { error: { status: 500, message: "Error retrieving replies of tweet. Check logs for details." }, data: null };
+    } else {
+        console.log(tweetReplies);
+        return { error: null, data: tweetReplies };
+    }
 }

--- a/lib/getUserData.ts
+++ b/lib/getUserData.ts
@@ -1,47 +1,58 @@
 import type { UserData } from "./types/userdata.types";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-export async function getUserSessionID(supabase: SupabaseClient<any, "public", any>) {
+export async function getUserSessionID(supabase: SupabaseClient<any, "public", any>): Promise<{ error: { status: 500 | 403, message: string } | null, id: string | null }> {
     const { data, error } = await supabase.auth.getSession();
 
     if (error) {
         console.error("getUserSessionID() Error: ", error);
-        return null;
+        return { error: { status: 500, message: "Server error retrieving session. Check logs for details." }, id: null };
     }
 
     if (!data.session) {
-        return { id: "" };
+        return { error: { status: 403, message: "Forbidden access, please sign in." }, id: null };
     }
 
-    return { id: data.session.user.id };
+    return { error: null, id: data.session.user.id };
 }
 
-export async function getUserDataByUsername(supabase: SupabaseClient<any, "public", any>, username: string) {
-    const noUser: UserData = {
-        id: "",
-        userName: "",
-        displayName: "",
-        createdAt: new Date(),
-        avatarUrl: "",
-        headerUrl: "",
-        bio: ""
-    };
-
+export async function getUserDataByUsername(supabase: SupabaseClient<any, "public", any>, username: string, currentUser: UserData): Promise<{ error: { status: 500 | 404 | 401, message: string } | null, userData: UserData | null}> {
+    
     const { data: userProfileData, error: userProfileDataError } = await supabase
-        .from("profile")
-        .select("*")
-        .eq("user_name", username);
-
+    .from("profile")
+    .select("*")
+    .eq("user_name", username);
+    
     if (userProfileDataError) {
         console.error("[getUserData() Error]: ", userProfileDataError);
-        return null;
+        return { error: { status: 500, message: "Server error retrieving profile data. Check logs for details." }, userData: null };
     }
-
-    if (!userProfileData.length) return noUser;
-
+    
+    if (!userProfileData.length) return { error: { status: 404, message: "No user found with provided username." }, userData: null };
+    
     const userArray = userProfileData as any[];
     const user = userArray[0];
+    
+    let currentUserOrIsFollowing: boolean = username === currentUser.userName; // Checks to see if it is the current user or is_following passes.
 
+    /* 
+    * Check to see if:
+    * - User's profile is private or public
+    * - If user's profile is public returns `true`.
+    * - If user's profile is private. If currentUser is not following user, returns `false`.
+    * Returns: boolean
+    */
+    if(!currentUserOrIsFollowing) {
+        const { data: isFollowing, error: isFollowingErr } = await supabase
+             .rpc('is_following', {
+                 current_profile_id: currentUser.id,
+                 requested_profile_id: user.id
+             })
+         if (isFollowingErr) console.error(isFollowingErr)
+         else currentUserOrIsFollowing = isFollowing;
+    }
+
+    
     const userProfile: UserData = {
         id: user.id,
         userName: user["user_name"],
@@ -49,24 +60,17 @@ export async function getUserDataByUsername(supabase: SupabaseClient<any, "publi
         createdAt: user["created_at"],
         avatarUrl: user["avatar_url"],
         headerUrl: user["header_url"],
-        bio: user.bio
+        bio: user.bio,
+        isPrivate: user["private_profile"],
     }
+    
+    if(!currentUserOrIsFollowing) return { error: { status: 401, message: "Unahotirzed access." }, userData: userProfile };
 
-    return userProfile;
+    return { error: null, userData: userProfile };
 }
 
-export async function getUserDataByID(supabase: SupabaseClient<any, "public", any>, userID: string | null): Promise<UserData | null> {
-    const noUser: UserData = {
-        id: "",
-        userName: "",
-        displayName: "",
-        createdAt: new Date(),
-        avatarUrl: "",
-        headerUrl: "",
-        bio: ""
-    };
-
-    if (!userID) return noUser;
+export async function getUserDataByID(supabase: SupabaseClient<any, "public", any>, userID: string | null): Promise<{ error: { status: 500 | 404, message: string } | null, userData: UserData | null }> {
+    if (!userID) return { error: { status: 404, message: "Missing ID field" }, userData: null };
 
     const { data: userProfileData, error: userProfileDataError } = await supabase
         .from("profile")
@@ -75,10 +79,10 @@ export async function getUserDataByID(supabase: SupabaseClient<any, "public", an
 
     if (userProfileDataError) {
         console.error("[getUserData() Error]: ", userProfileDataError);
-        return null;
+        return { error: { status: 500, message: "Error retrieving user data. Check logs for details." }, userData: null };
     }
 
-    if (!userProfileData.length) return noUser;
+    if (!userProfileData.length) return { error: { status: 404, message: "No user found with provided id." }, userData: null};
 
     const userArray = userProfileData as any[];
     const user = userArray[0];
@@ -90,8 +94,9 @@ export async function getUserDataByID(supabase: SupabaseClient<any, "public", an
         createdAt: user["created_at"],
         avatarUrl: user["avatar_url"],
         headerUrl: user["header_url"],
-        bio: user.bio
+        bio: user.bio,
+        isPrivate: user["private_profile"],
     }
 
-    return userProfile;
+    return { error: null, userData: userProfile };
 }

--- a/lib/types/tweet.types.ts
+++ b/lib/types/tweet.types.ts
@@ -1,17 +1,14 @@
-export type Profile = {
-  authorDisplayName: string,
-  authorUserName: string,
-  authorAvatarUrl: string,
-  authorHeaderUrl: string
-}
-
 export type Tweet = {
   id: string,
-  authorInfo: Profile,
-  textContent: string,
-  likeCount: string,
-  replyCount: string,
-  isReply: boolean,
-  createdAt: string,
-  hasLikedTweet?: boolean
+  display_name: string,
+  user_name: string,
+  avatar_url: string,
+  header_url: string,
+  post_content: string,
+  like_count: number,
+  reply_count: number,
+  created_at: string,
+  is_reply: boolean,
+  has_liked_tweet: boolean,
+  reply_to?: string
 }

--- a/lib/types/userdata.types.ts
+++ b/lib/types/userdata.types.ts
@@ -5,5 +5,6 @@ export type UserData = {
     createdAt: Date,
     avatarUrl: string,
     headerUrl: string,
-    bio: string
+    bio: string,
+    isPrivate: boolean
 }


### PR DESCRIPTION
- Created private profiles. When a user's profile is private so is every post and replies they make. It will only show if a user has made a like on a post publicly.
- Changed up how fetching `tweet` and `reply` data works. Data fetching function returns an object that will contain:
  - `error`: `Object | Null`
    - `Object`: 
      - `status`: An HTTP status error giving a heads up on what kind of error the fetching function returns.
      - `message`: A string containing information on what could be causing the error.
    - **⚠ CAUTION ⚠**: If the function is `getUserDataByUserame()` and the `status` is a **401**, then the data will still go through.
  - `data`: `Tweet | Tweet[] | Null`
    - `Tweet | Tweet[]`: Will return data if successfully fetched. **CAUTION** 
    - If not successful, then `Null` will be returned. **⚠ CAUTION ⚠**: If the function is `getUserDataByUserame()` and the `status` is a **401**, then the data will still go through.

Switched up how `Tweet` type and data is fetched. Changed it due to using the Supabase API in fetching the data instead of the Drizzle-ORM. 

`Tweet` Type and Data is now:
- `id`: `string`
- `display_name`: `string`
- `user_name`: `string`,
- `avatar_url`: `string`,
- `header_url`: `string`,
- `post_content`: `string`,
- `like_count`: `number`,
- `reply_count`: `number`,
- `created_at`: `string`,
- `is_reply`: `boolean`,
- `has_liked_tweet`: `boolean`,
- `reply_to?`: `string`